### PR TITLE
Fix packaging of submodules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,4 @@ packages = find:
 install_requires = file: requirements.txt
 
 [options.packages.find]
-include = yorzoi
+include = yorzoi*


### PR DESCRIPTION
## Summary
- include all subpackages when building distributions

## Testing
- `python -m build`
- `tar -xvzf dist/yorzoi-0.0.1.tar.gz -C /tmp/extract` 
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678dd48ab88328abcf8efeae7cf06a